### PR TITLE
update listings after clicking add new listing

### DIFF
--- a/server/models/listings/listingFunc.js
+++ b/server/models/listings/listingFunc.js
@@ -1,8 +1,8 @@
 let Listing = require("./listing");
 
 module.exports = {
-  getAll: (manager) => {
-    return Listing.find({ manager });
+  getAll: () => {
+    return Listing.find({});
   },
   deleteListing: (listingID) => {
     return Listing.findByIdAndDelete(listingID);

--- a/src/Components/App.jsx
+++ b/src/Components/App.jsx
@@ -10,7 +10,7 @@ import NavigationContainer from "../containers/Nav/NavigationContainer";
 
 const App = ({ getListings, currentPage }) => {
   useEffect(() => {
-    getListings("XYZ Properties");
+    getListings();
   }, []);
 
   if (currentPage === "home") {

--- a/src/Components/Tools/Agents/Preview/AddListing.jsx
+++ b/src/Components/Tools/Agents/Preview/AddListing.jsx
@@ -69,17 +69,17 @@ class AddListing extends React.Component {
         axios
           .post("/listings", { newListing: this.state })
           .then(({ data }) => {
-            console.log(data);
             this.props.addListing(data);
-
-            // this.setState({ listings: data });
           })
-          .then(() => this.props.getListings())
           .catch((err) => console.log(err));
       })
       .catch((err) => {
         console.log(err);
-      });
+      })
+      .then(() => {
+        this.props.getListings();
+      })
+      .catch((err) => console.log(err));
   }
 
   render() {

--- a/src/actions/Listings/getListingsThunk.js
+++ b/src/actions/Listings/getListingsThunk.js
@@ -1,15 +1,10 @@
 import axios from "axios";
 import thunk from "redux-thunk";
 import getListings from "./getListings";
-var getListingsThunk = (manager) => {
-  console.log("this is the thunk", manager);
+var getListingsThunk = () => {
   return (dispatch) => {
     axios
-      .get("/listings", {
-        params: {
-          manager,
-        },
-      })
+      .get("/listings")
       .then(({ data }) => {
         dispatch(getListings(data));
       })


### PR DESCRIPTION
Listings will update right after clicking the add new listing button.

Deleted the filtering based off managers to see all listings but routes are still there if we ever want to filter based off managers.